### PR TITLE
Fixed a bug in firm FOC in Aiyagari.jl

### DIFF
--- a/Julia/Aiyagari/AiyagariEGM.jl
+++ b/Julia/Aiyagari/AiyagariEGM.jl
@@ -45,7 +45,7 @@ end
 function PricesEGM(K,Z,params::AiyagariParametersEGM)
     @unpack β,α,δ,γ,ρ,σ,lamw,Lbar = params
     R = Z*α*(K/Lbar)^(α-1.0) + 1.0 - δ
-    w = Z*(1.0-α)*(K/Lbar)^(1.0-α) 
+    w = Z*(1.0-α)*(K/Lbar)^α 
     
     return AggVarsEGM(R,w)
 end


### PR DESCRIPTION
Aiyagari.jl has a function that maps capital and labor to wage and rental rate. There was a typo in the notes, python and Julia codes.